### PR TITLE
clj-kondo can report errors on line 0

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,9 +86,10 @@ function severity(level: string): vscode.DiagnosticSeverity {
 }
 
 function range(finding: Finding): vscode.Range {
-	return new vscode.Range(
-		finding.row - 1, finding.col,
-		finding.row - 1, finding.col);
+	// clj-kondo can report errors on line 0 col 0 when there is an unexpected
+	// error linting.
+	let row = Math.max(0, finding.row - 1);
+	return new vscode.Range(row, finding.col, row, finding.col);
 }
 
 function toDiagnostic(finding: Finding): vscode.Diagnostic {

--- a/src/test/errors.clj
+++ b/src/test/errors.clj
@@ -1,3 +1,5 @@
 (let [x 1]
   (let [y 1]
     (map)))
+
+(require '[clojure.test :refer :refer [deftest]])


### PR DESCRIPTION
In some cases, clj-kondo will report errors on line 0. Handle that case,
since vscode will throw an error when given a negative range.